### PR TITLE
Fix JavaScript time loading issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   <!-- GitHub repository link -->
   <p><a href="https://github.com/smaroukis/claude-code-actions-runner-test" target="_blank">View on GitHub</a></p>
   
-  <!-- Timer showing seconds since last main branch update -->
-  <p>Seconds since last main update: <span id="timer">Loading...</span></p>
+  <!-- Timer showing seconds since last update -->
+  <p>Seconds since last update: <span id="timer">Loading...</span></p>
   
   <h1>Claude-generated code below ↴</h1>
   <pre id="code">Loading…</pre>
@@ -22,10 +22,17 @@
     
     async function fetchLastCommit() {
       try {
-        const response = await fetch('https://api.github.com/repos/smaroukis/claude-code-actions-runner-test/commits/main');
+        const response = await fetch('https://api.github.com/repos/smaroukis/claude-code-actions-runner-test/commits');
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
         const data = await response.json();
-        lastCommitTime = new Date(data.commit.committer.date);
-        updateTimer();
+        if (data && data.length > 0) {
+          lastCommitTime = new Date(data[0].commit.committer.date);
+          updateTimer();
+        } else {
+          throw new Error('No commits found');
+        }
       } catch (error) {
         console.error('Error fetching last commit:', error);
         document.getElementById('timer').textContent = 'Error loading';


### PR DESCRIPTION
Fixes #12

Fixed the JavaScript timer that was stuck showing "Loading..." by:
- Changing GitHub API endpoint from `/commits/main` to `/commits`
- Adding better error handling and HTTP status checking
- Updating display text to "Seconds since last update"
- Fixing data access for array response

Generated with [Claude Code](https://claude.ai/code)